### PR TITLE
feat: add title and other metadata to layouts for improved SEO

### DIFF
--- a/src/pages/[...blog]/[category]/[...page].astro
+++ b/src/pages/[...blog]/[category]/[...page].astro
@@ -21,7 +21,7 @@ const { page, category } = Astro.props as Props;
 const currentPage = page.currentPage ?? 1;
 
 const metadata = {
-  title: `Category '${category}' ${currentPage > 1 ? ` — Page ${currentPage}` : ""}`,
+  title: `Blog posts by category — ${category} ${currentPage > 1 ? ` — page ${currentPage}` : ""}`,
   robots: {
     index: blogCategoryRobots?.index,
     follow: blogCategoryRobots?.follow,

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,6 +1,11 @@
 ---
 import Layout from "~/layouts/PageLayoutSansFooter.astro";
 const lastModified = "November 7, 2022";
+
+const metadata = {
+  title: "My acting resumé",
+  description: "Kevin Ashworth's Acting Resumé",
+};
 ---
 
 <style>
@@ -178,7 +183,7 @@ const lastModified = "November 7, 2022";
     animation: "shift-away",
   });
 </script>
-<Layout>
+<Layout metadata={metadata}>
   <div id="template" style="display: none;">
     A Public Reading of an Unproduced Screenplay About the Death of Walt&nbsp;Disney
   </div>

--- a/src/pages/web.astro
+++ b/src/pages/web.astro
@@ -1,6 +1,11 @@
 ---
 import Layout from "~/layouts/PageLayoutSansFooter.astro";
 const lastModified = "August 1, 2024";
+
+const metadata = {
+  title: "My web resumé",
+  description: "Kevin Ashworth's Web Resumé (Front-End Developer)",
+};
 ---
 
 <style>
@@ -130,7 +135,7 @@ const lastModified = "August 1, 2024";
   }
 </style>
 
-<Layout>
+<Layout metadata={metadata}>
   <div class="mx-auto mb-4 max-w-4xl">
     <div class="resume">
       <div class="mt-4 text-sm">


### PR DESCRIPTION
Add metadata to the Layout component in the resume pages.
Modify the blog category title for clarity and consistency.